### PR TITLE
increase restic timeout to 6

### DIFF
--- a/sandbox/cpdbr/oadp-dpa.yaml
+++ b/sandbox/cpdbr/oadp-dpa.yaml
@@ -28,7 +28,7 @@
                   memory: 256Mi
           restic:
             enable: true
-            timeout: 2h
+            timeout: 6h
             podConfig:
               resourceAllocations:
                 limits:

--- a/sandbox/cpdbr/oadp-dpa.yaml
+++ b/sandbox/cpdbr/oadp-dpa.yaml
@@ -21,8 +21,8 @@
             podConfig:
               resourceAllocations:
                 limits:
-                  cpu: "1"
-                  memory: 1Gi
+                  cpu: "2"
+                  memory: 4Gi
                 requests:
                   cpu: 500m
                   memory: 256Mi
@@ -32,7 +32,7 @@
             podConfig:
               resourceAllocations:
                 limits:
-                  cpu: "1"
+                  cpu: "2"
                   memory: 4Gi
                 requests:
                   cpu: 500m


### PR DESCRIPTION
to provide more timeout (6hrs) for cpdbr processes to complete

Signed-off-by: aishwarya.pradeep1@ibm.com