### PR TITLE
handle env name support

### DIFF
--- a/olm-utils-v2/deploy.sh
+++ b/olm-utils-v2/deploy.sh
@@ -15,8 +15,8 @@ readJsonConfig() {
 }
  
 
-CPAK_ADMIN_PASSWORD=$(readJsonConfig ".cp4dAdminPassword")
-CPAK_ENV_NAME=$(readJsonConfig ".cp4dEnvName")
+CPAK_ADMIN_PASSWORD=$(readJsonConfig ".cpakAdminPassword")
+CPAK_ENV_NAME=$(readJsonConfig ".cpakEnvName")
 
 #remove the cp4d pswd and env name incase it's an empty string in env file 
 sed -i 's/CPAK_ADMIN_PASSWORD=//' ./env-vars.sh

--- a/olm-utils-v2/openshift-config.yaml
+++ b/olm-utils-v2/openshift-config.yaml
@@ -22,7 +22,7 @@ vault:
   vault_authentication_type: none
 openshift:
 - name: cpd-demo
-  ocp_version: '4.10'
+  ocp_version: '4.12'
   cluster_name: cpd-demo
   domain_name: example.com
   console_banner: "Environment {{ env_id }}"


### PR DESCRIPTION
also make 4.12 as default ocp version instead of 4.10. this is needed for cp4ba deploy